### PR TITLE
Fix missing optional type in response

### DIFF
--- a/src/API/api.js
+++ b/src/API/api.js
@@ -75,8 +75,8 @@ export type SearchParams = {|
 |};
 
 export type ApiPoolsResponse = {|
-  world: World,
-  pools: {| [string]: Pool |},
+  world?: World,
+  pools?: {| [string]: Pool |},
 |};
 
 export function getPools(body: SearchParams): Promise<ApiPoolsResponse> {

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -84,12 +84,17 @@ function Home(props: HomeProps): Node {
   });
   const [openModal, setOpenModal] = React.useState<boolean>(false);
 
+  const toPoolArray: ?{| [string]: Pool |} => Array<Pool> = (pools) => {
+    if (pools == null) return [];
+    return Object.keys(pools).map(key => pools[key]);
+  };
+
   useEffect(() => {
     setStatus('pending');
     listPools()
       .then((poolsData: ApiPoolsResponse) => {
         setStatus('resolved');
-        setRowData(Object.keys(poolsData.pools).map(key => poolsData.pools[key]));
+        setRowData(toPoolArray(poolsData.pools))
       })
       .catch((err) => {
         setStatus('rejected');
@@ -107,7 +112,7 @@ function Home(props: HomeProps): Node {
     getPools(newSearch)
       .then((poolsData: ApiPoolsResponse) => {
         setStatus('resolved');
-        setRowData(Object.keys(poolsData.pools).map(key => poolsData.pools[key]));
+        setRowData(toPoolArray(poolsData.pools));
       })
       .catch((err) => {
         setStatus('rejected');
@@ -124,7 +129,7 @@ function Home(props: HomeProps): Node {
     getPools(newSearch)
       .then((poolsData: ApiPoolsResponse) => {
         setStatus('resolved');
-        setRowData(Object.keys(poolsData.pools).map(key => poolsData.pools[key]));
+        setRowData(toPoolArray(poolsData.pools));
       })
       .catch((err) => {
         setStatus('rejected');


### PR DESCRIPTION
The type `ApiPoolsResponse` had the incorrect type causing an issue when trying to access these fields when they were missing.