### PR TITLE
Show top 500 pools

### DIFF
--- a/src/API/api.js
+++ b/src/API/api.js
@@ -81,7 +81,7 @@ export type ApiPoolsResponse = {|
 
 export function getPools(body: SearchParams): Promise<ApiPoolsResponse> {
   const requestBody = {
-    ...{ search: '', sort: Sorting.SCORE, limit: 250 },
+    ...{ search: '', sort: Sorting.SCORE, limit: 500 },
     ...body,
   }
 


### PR DESCRIPTION
We used to show the top 250 pools by score, but with the increase to `k=500`, it makes sense for us to show the top 500 instead. (recall: all pools are visible if you use the search feature)

Slightly concerned about the performance of 500 entries, but probably it's okay.