### PR TITLE
monthly roa change to lifetime

### DIFF
--- a/src/components/DesktopTable.js
+++ b/src/components/DesktopTable.js
@@ -142,8 +142,8 @@ function DesktopTable({ data, delegateFunction, status, selectedIdPools, totalAd
     },
     {
       id: 1,
-      label: 'ROA 30d',
-      textInfo: 'Estimated ROA (Return of ADA, annualised) based on staking result from last 30 days'
+      label: 'ROA',
+      textInfo: 'Estimated ROA (Return of ADA, annualised) based on lifetime staking results'
     },
     {
       id: 2,


### PR DESCRIPTION
more of a cosmetic thing. ROA is already displayed with monthly value (it is more accurate and fairer for small pools than monthly). So it's just a matter of changing the column name.