### PR TITLE
hide saturation alert

### DIFF
--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -173,8 +173,8 @@ function Home(props: HomeProps): Node {
     }
   };
 
-  const alertText = 'The new saturation point for Stakepools will be 63.6 million ADA from December 6th. If the "Pool Size" parameter of your Stakepool is over this limit, delegate to a new stakepool to avoid less than expected rewards';
-
+  const alertText = false;
+  
   function filterPools(
     pools: ?Array<Pool>,
     totalAda: ?number,

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -173,7 +173,7 @@ function Home(props: HomeProps): Node {
     }
   };
 
-  const alertText = false;
+  const alertText = null;
   
   function filterPools(
     pools: ?Array<Pool>,


### PR DESCRIPTION
it is used for the saturation change message. it is currently useless, rather it is in the way, everyone already knows that. I reckon this function will be used again when k = 1000