### PR TITLE
pledge bg changes (r)

### DIFF
--- a/src/components/PledgeCard.js
+++ b/src/components/PledgeCard.js
@@ -31,28 +31,19 @@ type Props = {|
 function PledgeCard({ value, real }: Props): Node {
   
   // to fix according to ranges
-  let backgroundColor = null;
+  let backgroundColor = 'none';
   const realValue = Number(value) / 1000000; // divided in 1,000,000 to convert from Lovelace to ADA
 
-  switch(true){
-  case realValue >= 250000:
+  if (realValue >= 250000) {
     backgroundColor = '#BFC8FF';
-    break;
-  case realValue < 200000 && realValue >= 100000:
+  } else if (realValue >= 100000) {
     backgroundColor = '#D6DDF5';
-    break;
-  case realValue < 100000 && realValue >= 500000:
+  } else if (realValue >= 500000) {
     backgroundColor = '#FBF6B7';
-    break;
-  case realValue < 500000 && realValue >= 20000:
+  } else if (realValue >= 20000) {
     backgroundColor = '#FCE4BC';
-    break;
-  case realValue < 20000 && realValue >= 0:
+  } else if (realValue > 0) {
     backgroundColor = '#FFDCE5';
-    break;
-  default:
-    backgroundColor = 'none';
-    break;
   }
   
   return (

--- a/src/components/PledgeCard.js
+++ b/src/components/PledgeCard.js
@@ -35,19 +35,19 @@ function PledgeCard({ value, real }: Props): Node {
   const realValue = Number(value) / 1000000; // divided in 1,000,000 to convert from Lovelace to ADA
 
   switch(true){
-  case realValue >= 1e6:
+  case realValue >= 250000:
     backgroundColor = '#BFC8FF';
     break;
-  case realValue < 1e6 && realValue >= 150e3:
+  case realValue < 200000 && realValue >= 100000:
     backgroundColor = '#D6DDF5';
     break;
-  case realValue < 150e3 && realValue >= 100e3:
+  case realValue < 100000 && realValue >= 500000:
     backgroundColor = '#FBF6B7';
     break;
-  case realValue < 100e3 && realValue >= 50e3:
+  case realValue < 500000 && realValue >= 20000:
     backgroundColor = '#FCE4BC';
     break;
-  case realValue < 50e3 && realValue >= 0:
+  case realValue < 20000 && realValue >= 0:
     backgroundColor = '#FFDCE5';
     break;
   default:

--- a/src/components/PledgeCard.js
+++ b/src/components/PledgeCard.js
@@ -32,15 +32,15 @@ function PledgeCard({ value, real }: Props): Node {
   
   // to fix according to ranges
   let backgroundColor = 'none';
-  const realValue = Number(value) / 1000000; // divided in 1,000,000 to convert from Lovelace to ADA
+  const realValue = Number(value) / 1_000_000; // divided in 1,000,000 to convert from Lovelace to ADA
 
-  if (realValue >= 250000) {
+  if (realValue >= 250_000) {
     backgroundColor = '#BFC8FF';
-  } else if (realValue >= 100000) {
+  } else if (realValue >= 100_000) {
     backgroundColor = '#D6DDF5';
-  } else if (realValue >= 500000) {
+  } else if (realValue >= 50_000) {
     backgroundColor = '#FBF6B7';
-  } else if (realValue >= 20000) {
+  } else if (realValue >= 20_000) {
     backgroundColor = '#FCE4BC';
   } else if (realValue > 0) {
     backgroundColor = '#FFDCE5';


### PR DESCRIPTION
those figures were taken when the ADA was $0.1 or whatever. :) so nowadays it's great if the pool pledge is 100-500k. and there is no point in highlighting the big ones with 2M anymore - if only because most of them don't own the pledge anyway, but have it "on loan" (just the stake key, no private keys)

Updated pledge ranges are:
| old | new |
|---|---|
| `<50k` | `<20k` |
| `50k-100k` | `20k-50k` |
| `100k-150k` | `50k-100k` |
| `150k-1M` | `100k-250k` |
| `>1M` | `>250k` |