### PR TITLE
Estimated costs removal 

### DIFF
--- a/src/components/DesktopTable.js
+++ b/src/components/DesktopTable.js
@@ -10,7 +10,6 @@ import CardRoa from './CardRoa';
 import { roundTwoDecimal, formatBigNumber, formatCostLabel } from '../utils/utils';
 import Button from './common/Button';
 import Tooltip from './common/Tooltip';
-import AverageCostCard from './AverageCostCard';
 import type { QueryState } from '../utils/types';
 import type { DelegationProps } from '../containers/Home';
 
@@ -157,16 +156,11 @@ function DesktopTable({ data, delegateFunction, status, selectedIdPools, totalAd
     },
     {
       id: 4,
-      label: 'Average Cost',
-      textInfo: 'Real average fees'
-    },
-    {
-      id: 5,
       label: 'Pledge',
       textInfo: 'Available Pledge'
     },
     {
-      id: 6,
+      id: 5,
       label: 'Blocks',
       textInfo: 'Minted blocks in actual epoch + block trend; Background = today estimated performance'
     },
@@ -217,11 +211,6 @@ function DesktopTable({ data, delegateFunction, status, selectedIdPools, totalAd
                 <td>
                   <CostsCard
                     value={formatCostLabel(Number(pool.tax_ratio), pool.tax_fix)}
-                  />
-                </td>
-                <td>
-                  <AverageCostCard
-                    percentage={roundTwoDecimal(pool.tax_computed)}
                   />
                 </td>
                 <td>

--- a/src/components/DesktopTable.js
+++ b/src/components/DesktopTable.js
@@ -7,7 +7,7 @@ import PoolSizeCard from './PoolSizeCard';
 import CostsCard from './CostsCard';
 import PledgeCard from './PledgeCard';
 import CardRoa from './CardRoa';
-import { roundTwoDecimal, formatBigNumber, formatCostLabel } from '../utils/utils';
+import { formatBigNumber, formatCostLabel } from '../utils/utils';
 import Button from './common/Button';
 import Tooltip from './common/Tooltip';
 import type { QueryState } from '../utils/types';


### PR DESCRIPTION
This change removes the column estimated costs. This is because 
db-sync already provides a breakdown of rewards for delegators and for the operator separately, so the "ROA" value will contain the reward that the delegator can expect and therefore there is no need to estimate the second column.

Delegates are primarily interested in their own appreciation. So it is confusing to show how much the pool earns for everyone in this metric. There is no reason for a pool with 10% fee to have that 10% included in ROA, because the delegator will never get that ROA.

The result will be simplification while maintaining information value and a better user experience.