### PR TITLE
Allow different origins to listen to first ADA pool message

### DIFF
--- a/src/API/yoroi.js
+++ b/src/API/yoroi.js
@@ -61,5 +61,5 @@ export const SendFirstAdapool = (firstPool: Object): void => {
     avatar: firstPool.pool_pic
   };
   const encodedFirstPool = encodeURI(JSON.stringify(poolInfo));
-  window.parent.postMessage(encodedFirstPool);
+  window.parent.postMessage(encodedFirstPool, '*');
 }


### PR DESCRIPTION
According to `postMessage` docs: if `targetOrigin` not provided, it defaults to "/". This default restricts the message to same-origin targets only.

We provide `targetOrigin` as `*` so the extension is also notified of the message. We might want to switch from `*` to something specific to Yoroi, but I it doesn't seem to be a security issue to have it as `*` **as long as the data we include in this message is not sensitive**.

Related: Emurgo/yoroi-frontend#2519