### PR TITLE
List Emurgo pools at the top of the delegation list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15640,6 +15640,11 @@
         "ajv-keywords": "^3.5.2"
       }
     },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-minimal-pie-chart": "^8.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
+    "seedrandom": "^3.0.5",
     "styled-components": "^5.2.1"
   },
   "scripts": {

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -100,7 +100,7 @@ export type ApiPoolsResponse = {|
 
 const toPoolArray: (?{| [string]: Pool |}) => Array<Pool> = (pools) => {
   if (pools == null) return [];
-  return Object.keys(pools).map((key) => pools[key]);
+  return Object.keys(pools).map((key) => pools[key]).filter(x => x != null);
 }
 
 export function getPools(body: SearchParams): Promise<ApiPoolsResponse> {

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -162,6 +162,10 @@ export async function listBiasedPools(seed: string, searchParams: SearchParams):
   const unbiasedPoolsResponse = await getPools(searchParams);
   const unbiasedPools = toPoolArray(unbiasedPoolsResponse.pools);
 
+  if (searchParams.search || searchParams.sort === Sorting.TICKER) {
+    return unbiasedPools;
+  }
+
   const [p1, p2, p3] = unbiasedPools;
   const lowerSeed = tail(p1?.id ?? '') + tail(p2?.id ?? '') + tail(p3?.id ?? '');
 

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -156,7 +156,6 @@ export async function listBiasedPools(seed: string): Promise<Pool[]> {
     if (unbiasedPools.length === 0) return biasedPools;
 
     const topPool = biasedPools.shift();
-    const allPools = [topPool].concat(unbiasedPools);
 
     /*
       we want to list the Emurgo pools in high-ish positions.
@@ -175,14 +174,6 @@ export async function listBiasedPools(seed: string): Promise<Pool[]> {
     // needs to be at least this distance from the top
     const minimumDistanceFromTop = 10;
 
-    for (let i = 0; i < biasedPools.length; i += 1) {
-      const biasedPool = biasedPools[i];
-      const minPossiblePosition = minimumDistanceFromTop + (spreadSize * (i + 1));
-      const maxPossiblePosition = minPossiblePosition + spreadSize
-      const randomPosition = getRandomInt(minPossiblePosition, maxPossiblePosition);
-      allPools.splice(randomPosition, 0, biasedPool);
-    }
-
     for (let i = 0; i < biasPoolIds.length; i += 1) {
       const poolId = biasPoolIds[i];
       const poolToRemove = unbiasedPools.find(p => p.id === poolId);
@@ -192,6 +183,16 @@ export async function listBiasedPools(seed: string): Promise<Pool[]> {
           unbiasedPools.splice(poolToRemoveIdx, 1);
         }
       }
+    }
+
+    const allPools = [topPool].concat(unbiasedPools);
+
+    for (let i = 0; i < biasedPools.length; i += 1) {
+      const biasedPool = biasedPools[i];
+      const minPossiblePosition = minimumDistanceFromTop + (spreadSize * (i + 1));
+      const maxPossiblePosition = minPossiblePosition + spreadSize
+      const randomPosition = getRandomInt(minPossiblePosition, maxPossiblePosition);
+      allPools.splice(randomPosition, 0, biasedPool);
     }
 
     return allPools;

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -181,12 +181,9 @@ export async function listBiasedPools(seed: string, searchParams: SearchParams):
     // removes the Emurgo pools from the original list, as we are reinserting it later
     for (let i = 0; i < biasPoolIds.length; i += 1) {
       const poolId = biasPoolIds[i];
-      const poolToRemove = unbiasedPools.find(p => p.id === poolId);
-      if (poolToRemove) {
-        const poolToRemoveIdx = unbiasedPools.indexOf(poolToRemove);
-        if (poolToRemoveIdx > -1) {
-          unbiasedPools.splice(poolToRemoveIdx, 1);
-        }
+      const poolToRemoveIdx = unbiasedPools.findIndex(p => p.id === poolId);
+      if (poolToRemoveIdx >= 0) {
+        unbiasedPools.splice(poolToRemoveIdx, 1);
       }
     }
 

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -1,9 +1,20 @@
 // @flow
 
 import axios from 'axios';
+import seedrandom from 'seedrandom';
 import { BACKEND_URL } from '../manifestEnvs';
 
 const backendUrl: string = BACKEND_URL;
+
+const biasPoolIds = [
+  'df1750df9b2df285fcfb50f4740657a18ee3af42727d410c37b86207',
+  'af22f95915a19cd57adb14c558dcc4a175f60c6193dc23b8bd2d8beb',
+  '04357793d81097a7d2c15ec6cd6067a58cdd2fb21aaf07e56c306ecf',
+  'c34a7f59c556633dc88ec25c9743c5ebca3705e179a54db5638941cb',
+  'c5293f2ba88ac474787358b9c2f4fae7b3c4408f79cdf89a12c9ece4',
+  '8145274aa1713d4569e0d946af510b4d2b80640d87c1a0e4e0517954',
+];
+const biasPoolsSearchQuery = biasPoolIds.join('|');
 
 export type HistBPE = {|
   +val: string,
@@ -106,6 +117,88 @@ export function getPools(body: SearchParams): Promise<ApiPoolsResponse> {
         pools: {}
       }
     });
+}
+
+const toPoolArray: (?{| [string]: Pool |}) => Array<Pool> = (pools) => {
+  if (pools == null) return [];
+  return Object.keys(pools).map((key) => pools[key]);
+}
+
+function rndSign(seed: string) {
+  const rnd = seedrandom(seed);
+  return () => {
+    return Math.sign(rnd() * 2 - 1);
+  }
+}
+
+const sortBiasedPools = (pools: Pool[], seed: string) => {
+  const rev = seed.split('').reverse().join('');
+  return [...pools]
+    .sort(rndSign(seed))
+    .sort(rndSign(rev));
+}
+
+function getRandomInt(min: number, max: number) {
+  const intMin = Math.ceil(min);
+  const intmax = Math.floor(max);
+  return Math.floor(Math.random() * (intmax - intMin + 1)) + intMin;
+}
+
+export async function listBiasedPools(seed: string): Promise<Pool[]> {
+  const unbiasedPoolsResponse = await getPools(({}: any));
+  const unbiasedPools = toPoolArray(unbiasedPoolsResponse.pools);
+
+  try {
+    const biasedPoolsResponse = await getPools(({ search: biasPoolsSearchQuery }));
+    if (!biasedPoolsResponse) return unbiasedPools;
+    const biasedPools = sortBiasedPools(toPoolArray(biasedPoolsResponse.pools), seed);
+    if (!biasedPools || biasedPools.length === 0) return unbiasedPools;
+    if (unbiasedPools.length === 0) return biasedPools;
+
+    const topPool = biasedPools.shift();
+    const allPools = [topPool].concat(unbiasedPools);
+
+    /*
+      we want to list the Emurgo pools in high-ish positions.
+      for that, we define a spread size which is used to define a range of
+      possible positions for each pool to be inserted into the final set (allPools).
+
+      with a `spreadBias` of `3`, it means the Emurgo pools will be all roughly in the top 33%
+      of listed pools, but all separated by the value of spreadSize.
+
+      notice that spreadSize is based on the length of unbiasedPools as well, so the more
+      unbiased pools we have, the higher the spread will be.
+    */
+    const spreadBias = 3;
+    const spreadSize = Math.trunc(Math.trunc(unbiasedPools.length / spreadBias) / biasedPools.length);
+    // since we already list an Emurgo pool in the top, we say that the next Emurgo pool
+    // needs to be at least this distance from the top
+    const minimumDistanceFromTop = 10;
+
+    for (let i = 0; i < biasedPools.length; i += 1) {
+      const biasedPool = biasedPools[i];
+      const minPossiblePosition = minimumDistanceFromTop + (spreadSize * (i + 1));
+      const maxPossiblePosition = minPossiblePosition + spreadSize
+      const randomPosition = getRandomInt(minPossiblePosition, maxPossiblePosition);
+      allPools.splice(randomPosition, 0, biasedPool);
+    }
+
+    for (let i = 0; i < biasPoolIds.length; i += 1) {
+      const poolId = biasPoolIds[i];
+      const poolToRemove = unbiasedPools.find(p => p.id === poolId);
+      if (poolToRemove) {
+        const poolToRemoveIdx = unbiasedPools.indexOf(poolToRemove);
+        if (poolToRemoveIdx > -1) {
+          unbiasedPools.splice(poolToRemoveIdx, 1);
+        }
+      }
+    }
+
+    return allPools;
+  } catch (err) {
+    return unbiasedPools;
+  }
+  
 }
 
 export function listPools(): Promise<ApiPoolsResponse> {

--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,7 @@ const extractParams = (locationSearch: string): UrlParams => {
     // $FlowFixMe[incompatible-return]
     totalAda: Number(params.get('totalAda')),
     layout: params.get('layout'),
+    bias: params.get('bias'),
   };
 };
 

--- a/src/components/DesktopTable.js
+++ b/src/components/DesktopTable.js
@@ -185,7 +185,7 @@ function DesktopTable({ data, delegateFunction, status, selectedIdPools, totalAd
         </thead>
         <tbody>
           {data != null &&
-            data.map(pool => (
+            data.filter(x => x != null).map(pool => (
               <tr role="row" key={pool.id}>
                 <td>
                   <StakingPoolCard

--- a/src/components/DesktopTableRevamp.js
+++ b/src/components/DesktopTableRevamp.js
@@ -189,7 +189,7 @@ function DesktopTableRevamp({
         </thead>
         <tbody>
           {data != null &&
-            data.map((pool) => (
+            data.filter(x => x != null).map((pool) => (
               <tr role="row" key={pool.id}>
                 <td>
                   <StakingPoolCardRevamp

--- a/src/components/MobileTable.js
+++ b/src/components/MobileTable.js
@@ -75,7 +75,7 @@ function MobileTable({ data, delegateFunction, status, selectedIdPools, totalAda
   return (
     <>
       {data &&
-        data.map(pool => (
+        data.filter(x => x != null).map(pool => (
           <CardMobile key={pool.id}>
             <StakingPoolCard
               id={pool.id}

--- a/src/components/MobileTableRevamp.js
+++ b/src/components/MobileTableRevamp.js
@@ -79,7 +79,7 @@ function MobileTableRevamp({ data, delegateFunction, status, selectedIdPools, to
   return (
     <>
       {data &&
-        data.map(pool => (
+        data.filter(x => x != null).map(pool => (
           <CardMobile key={pool.id}>
             <StakingPoolCardRevamp
               id={pool.id}

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -73,6 +73,7 @@ export type UrlParams = {|
     lang: ?string,
     totalAda: ?number,
     layout: ?string,
+    bias: ?string
 |};
 
 export type HomeProps = {|

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -9,8 +9,8 @@ import Alert from '../components/Alert';
 import { YoroiCallback } from '../API/yoroi';
 
 import { DesktopOnly, MobileOnly } from '../components/layout/Breakpoints';
-import { getPools, listBiasedPools, listPools } from '../API/api';
-import type { ApiPoolsResponse, Pool, SearchParams } from '../API/api';
+import { listBiasedPools } from '../API/api';
+import type { Pool, SearchParams } from '../API/api';
 import DesktopTable from '../components/DesktopTable';
 import MobileTable from '../components/MobileTable';
 import SortSelect from '../components/SortSelect';

--- a/src/containers/HomeRevamp.js
+++ b/src/containers/HomeRevamp.js
@@ -8,8 +8,8 @@ import Alert from '../components/Alert';
 import { SendFirstAdapool, YoroiCallback } from '../API/yoroi';
 
 import { DesktopOnly, MobileOnly } from '../components/layout/Breakpoints';
-import { getPools, listBiasedPools } from '../API/api';
-import type { ApiPoolsResponse, Pool, SearchParams } from '../API/api';
+import { listBiasedPools } from '../API/api';
+import type { Pool, SearchParams } from '../API/api';
 import SortSelect from '../components/SortSelect';
 import type { QueryState } from '../utils/types';
 
@@ -114,17 +114,12 @@ function Home(props: HomeProps): Node {
   const [confirmDelegationModal, setConfirmDelegationModal] = React.useState<boolean>(false);
   const [delegationModalData, setDelegationModalData] = React.useState<Object>({});
 
-  const toPoolArray: (?{| [string]: Pool |}) => Array<Pool> = (pools) => {
-    if (pools == null) return [];
-    return Object.keys(pools).map((key) => pools[key]);
-  };
-
   const { urlParams } = props;
   const seed = urlParams?.bias ?? 'bias';
 
   useEffect(() => {
     setStatus('pending');
-    listBiasedPools(seed)
+    listBiasedPools(seed, {})
       .then((pools: Pool[]) => {
         setStatus('resolved');
         setRowData(pools);
@@ -144,10 +139,10 @@ function Home(props: HomeProps): Node {
     };
     setFilterOptions(newSearch);
     setStatus('pending');
-    getPools(newSearch)
-      .then((poolsData: ApiPoolsResponse) => {
+    listBiasedPools(seed, newSearch)
+      .then((pools: Pool[]) => {
         setStatus('resolved');
-        setRowData(toPoolArray(poolsData.pools));
+        setRowData(pools);
       })
       .catch((err) => {
         setStatus('rejected');
@@ -161,10 +156,10 @@ function Home(props: HomeProps): Node {
     };
     setFilterOptions(newSearch);
     setStatus('pending');
-    getPools(newSearch)
-      .then((poolsData: ApiPoolsResponse) => {
+    listBiasedPools(seed, newSearch)
+      .then((pools: Pool[]) => {
         setStatus('resolved');
-        setRowData(toPoolArray(poolsData.pools));
+        setRowData(pools);
       })
       .catch((err) => {
         setStatus('rejected');

--- a/src/containers/HomeRevamp.js
+++ b/src/containers/HomeRevamp.js
@@ -8,7 +8,7 @@ import Alert from '../components/Alert';
 import { SendFirstAdapool, YoroiCallback } from '../API/yoroi';
 
 import { DesktopOnly, MobileOnly } from '../components/layout/Breakpoints';
-import { getPools, listPools } from '../API/api';
+import { getPools, listBiasedPools } from '../API/api';
 import type { ApiPoolsResponse, Pool, SearchParams } from '../API/api';
 import SortSelect from '../components/SortSelect';
 import type { QueryState } from '../utils/types';
@@ -89,6 +89,7 @@ export type UrlParams = {|
   lang: ?string,
   totalAda: ?number,
   layout: ?string,
+  bias: ?string,
 |};
 
 export type HomeProps = {|
@@ -118,14 +119,17 @@ function Home(props: HomeProps): Node {
     return Object.keys(pools).map((key) => pools[key]);
   };
 
+  const { urlParams } = props;
+  const seed = urlParams?.bias ?? 'bias';
+
   useEffect(() => {
     setStatus('pending');
-    listPools()
-      .then((poolsData: ApiPoolsResponse) => {
+    listBiasedPools(seed)
+      .then((pools: Pool[]) => {
         setStatus('resolved');
-        setRowData(toPoolArray(poolsData.pools));
+        setRowData(pools);
         // used to show the first pool in revamp banner
-        SendFirstAdapool(toPoolArray(poolsData.pools)[0])
+        SendFirstAdapool(pools[0])
       })
       .catch((err) => {
         setStatus('rejected');
@@ -169,8 +173,6 @@ function Home(props: HomeProps): Node {
   };
 
   const confirmedDelegateFunction = (id: string): void => {
-    const { urlParams } = props;
-
     YoroiCallback([id], {
       source: urlParams.source,
       chromeId: urlParams.chromeId,

--- a/src/containers/HomeRevamp.js
+++ b/src/containers/HomeRevamp.js
@@ -202,7 +202,9 @@ function Home(props: HomeProps): Node {
 
     if (lovelaceDelegation > SATURATION_LIMIT) return pools;
 
-    return pools.filter((item) => Number(item.total_stake) + lovelaceDelegation < SATURATION_LIMIT);
+    return pools.filter((item) => {
+      return item != null && (Number(item.total_stake) + lovelaceDelegation < SATURATION_LIMIT);
+    });
   }
 
   const {


### PR DESCRIPTION
# Abstract
This PR changes the delegation list order to give priority for pools ran by Emurgo by randomly selecting one of them to be at the top based on a seed, and spreading the remaining Emurgo pools among the top of the list

# Implementation
First things first, we make changes to `App.js`, `Home.js` and `HomeRevamp.js` to accept the `bias` query string parameter.

We then define a new function in `api.js` to return the full list of pools with the bias for the Emurgo pools and change`HomeRevamp.js` to use this function instead of `listPools`.

The `listBiasedPools` function makes 2 separated requests: one to get the "unbiased" pools and another one to get only the Emurgo pools. We then remove all Emurgo pools from the unbiased pools set so we can re-insert them later in the appropriate positions. The Emurgo pools are re-inserted in the full pools set according to the criteria:
- we randomize the order of the Emurgo pools based on the bias;
- the first Emurgo pool from the randomized set is inserted at the top of the full set;
- the remaining Emurgo pools are inserted into a random position respecting the ranges from the `brackets` variable;

The `listBiasedPools` function also takes the `SearchParams` argument and based on it, decides to wether it should apply the bias or not. Currently, we only apply the bias if the sorting is not by ticker and if no search string was provided. In these cases we want users to see the unbiased list of pools.

With the above, we construct the list of pools with a seeded random Emurgo pool at the top, and the remaining pools spread across the upper part of the list.

Finally, we change the initial fetching of pools and the pool searching from `HomeRevamp.js` to use `listBiasedPools`.