### PR TITLE
fix(delegate): button red bg and hover bg

### DIFF
--- a/src/components/common/Button.js
+++ b/src/components/common/Button.js
@@ -71,9 +71,9 @@ const BtnRevampWrapper = styled.button`
   }
 
   &:disabled {
-    background: red;
     color: #a0b3f2;
     cursor: not-allowed;
+    background-color: transparent;
   }
 `;
 


### PR DESCRIPTION
**Description**
When disabled, the delegate button had a red background, also a hover background even tho it shouldn't.

Task: https://emurgo.atlassian.net/browse/YOEXT-933

**Screenshot**
![image](https://github.com/user-attachments/assets/56c97553-ee1d-436a-9e38-47f6847a399d)
 