### PR TITLE
Change default sort of pool search from 'score' to 'roa' 

### DIFF
--- a/src/API/api.js
+++ b/src/API/api.js
@@ -125,7 +125,7 @@ const toPoolArray: (?{| [string]: Pool |}) => Array<Pool> = (pools) => {
 
 export function getPools(body: SearchParams): Promise<ApiPoolsResponse> {
   const requestBody = {
-    ...{ search: '', sort: Sorting.SCORE, limit: 250 },
+    ...{ search: '', sort: Sorting.ROA, limit: 250 },
     ...body,
   };
 

--- a/src/components/SortSelect.js
+++ b/src/components/SortSelect.js
@@ -48,14 +48,14 @@ type Props = {|
 |};
 
 export const sortingSelectData = [
-  { label: 'Score', value: Sorting.SCORE }, // default option on load
+  { label: 'ROA', value: Sorting.ROA }, // default option on load
   { label: 'Ticker and name', value: Sorting.TICKER },
 ];
 
 export const sortingSelectDataRevamp = [
-  { label: 'Score', value: Sorting.SCORE }, // default option on load
+  { label: 'ROA', value: Sorting.ROA }, // default option on load
+  { label: 'Score', value: Sorting.SCORE },
   { label: 'Ticker and name', value: Sorting.TICKER },
-  { label: 'ROA', value: Sorting.ROA },
   { label: 'Pool size', value: Sorting.POOL_SIZE },
   { label: 'Saturation', value: Sorting.SATURATION },
   { label: 'Costs', value: Sorting.COSTS },
@@ -64,7 +64,7 @@ export const sortingSelectDataRevamp = [
 ];
 
 function SortSelect({ filter, isRevamp = true, isDark }: Props): React$Node {
-  const [selectValue, setSelectValue] = React.useState<SortingEnum>('score');
+  const [selectValue, setSelectValue] = React.useState<SortingEnum>('roa');
 
   const handleChange = (e) => {
     setSelectValue(e.currentTarget.value);

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -100,7 +100,7 @@ function Home(props: HomeProps): Node {
   const [status, setStatus] = React.useState<QueryState>('idle');
   const [filterOptions, setFilterOptions] = React.useState<SearchParams>({
     search: '',
-    sort: 'score',
+    sort: 'roa',
   });
   const [openModal, setOpenModal] = React.useState<boolean>(false);
   const [confirmDelegationModal, setConfirmDelegationModal] = React.useState<boolean>(false);

--- a/src/containers/HomeRevamp.js
+++ b/src/containers/HomeRevamp.js
@@ -155,7 +155,7 @@ function Home(props: HomeProps): Node {
   const [status, setStatus] = React.useState<QueryState>('idle');
   const [filterOptions, setFilterOptions] = React.useState<SearchParams>({
     search: '',
-    sort: Sorting.SCORE,
+    sort: Sorting.ROA,
     sortDirection: SortingDirections.ASC,
   });
   const [openModal, setOpenModal] = React.useState<boolean>(false);


### PR DESCRIPTION
For your consideration: the purpose of the change is to encourage better stake distribution within Cardano ecosystem - currently 'score' sort seems to return mostly the same pools month after month (I've taken a few snapshots over the past x months), majority of them already with adequate stake and regular block production.