### PR TITLE
roa sorting fix

### DIFF
--- a/src/API/api.js
+++ b/src/API/api.js
@@ -135,9 +135,6 @@ function transformData(poolsResponse) {
 function convertSortingToBackendSorting(sorting: ?SortingEnum): string {
   if (sorting === Sorting.SCORE) return 'ranking';
   if (sorting === Sorting.ROA) return 'roa_lifetime';
-  if (sorting === Sorting.POOL_SIZE) return 'live_stake';
-  if (sorting === Sorting.PLEDGE) return 'pledge';
-  if (sorting === Sorting.BLOCKS) return 'blocks';
   return 'ranking';
 }
 
@@ -149,9 +146,7 @@ function getPools(network: 'mainnet' | 'preprod', body: SearchParams, bias: ?str
   };
 
   const searchParams = new URLSearchParams();
-  if (requestBody.sort === 'ranking') {
-    searchParams.append('order', 'ranking');
-  }
+  searchParams.append('order', requestBody.sort ?? 'ranking');
   if (requestBody.limit) {
     searchParams.append('limit', String(requestBody.limit));
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure ROA sorting works by always sending `order` with backend sort value and dropping unused sort options.
> 
> - **API: pool fetching (`src/API/api.js`)**
>   - Always append `order` using backend sort (`requestBody.sort` or `ranking`) when building query params in `getPools`.
>   - Simplify sort mapping: keep `SCORE -> ranking`, `ROA -> roa_lifetime`; remove mappings for `POOL_SIZE`, `PLEDGE`, and `BLOCKS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ea3d1c8ec5ab05fb0768650a8b27b4cbf97e4cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->